### PR TITLE
Remove delete reason label on account delete page

### DIFF
--- a/decidim-core/app/views/decidim/account/delete.html.erb
+++ b/decidim-core/app/views/decidim/account/delete.html.erb
@@ -8,7 +8,7 @@
       <div>
         <label>
           <span class="user-form__label"><%= t('activemodel.attributes.account.delete_reason') %></span>
-          <%= f.text_area :delete_reason, rows: 2 %>
+          <%= f.text_area :delete_reason, rows: 2, label: false %>
         </label>
       </div>
       <input type="submit" class="button open-modal-button" value="<%= t('.confirm.title') %>" />


### PR DESCRIPTION
#### :tophat: What? Why?
Label should be removed, since its text is not translated and there is already a heading text.

#### :pushpin: Related Issues

### :camera: Screenshots (optional)
![imagen](https://user-images.githubusercontent.com/453545/34050670-fb65d240-e1bb-11e7-9ff2-5d141166662a.png)

#### :ghost: GIF
![delete](http://gifs.gifme.io/i/83ea320f1f.gif)

